### PR TITLE
Potential fix for code scanning alert no. 5: Disabled Spring CSRF protection

### DIFF
--- a/storage-service/src/main/java/com/github/advancedsecurity/storageservice/WebSecurityConfig.java
+++ b/storage-service/src/main/java/com/github/advancedsecurity/storageservice/WebSecurityConfig.java
@@ -44,7 +44,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 		BearerAuthenticationFilter filter = new BearerAuthenticationFilter(authenticationManager(), this.antPattern);
 		filter.setAuthenticationSuccessHandler(jwtAuthenticationSuccessHandler);
 		http.cors().and()
-			 .csrf().disable()
+			 .csrf(csrf -> csrf.ignoringAntMatchers("/api/public/**")) // Enable CSRF protection but ignore specific endpoints
 			 .authorizeRequests().antMatchers(this.antPattern).authenticated().and()
 			 .addFilterBefore(filter, UsernamePasswordAuthenticationFilter.class)
 			 .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);


### PR DESCRIPTION
Potential fix for [https://github.com/fraviltor/ghas-jotb/security/code-scanning/5](https://github.com/fraviltor/ghas-jotb/security/code-scanning/5)

To fix the issue, CSRF protection should be re-enabled by removing the `http.csrf().disable()` call. If there are specific endpoints that do not require CSRF protection (e.g., APIs used by non-browser clients), those endpoints can be explicitly excluded from CSRF protection using Spring's `CsrfConfigurer.ignoringAntMatchers()` method. This approach ensures that CSRF protection is enabled for all other endpoints.

The changes will be made in the `configure(HttpSecurity http)` method of the `WebSecurityConfig` class. The `http.csrf().disable()` line will be replaced with a configuration that enables CSRF protection while ignoring specific endpoints if necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
